### PR TITLE
Add CHANGELOG and update class dependency color configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [0.1.0] - 2025-03-08
+
+Initial version of the extension.
+
+## [0.2.0] - 2025-03-08
+
+### Added
+
+- Updated version to 0.2.0
+- Changed default class dependency color from lightgrey to lightblue
+- Improved description for class dependency color.
+
+### Fixed
+
+- Corrected inconsistencies in documentation formatting and phrasing.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Generate interactive dependency graphs for C# projects and classes directly from Visual Studio Code.
 
+## Change Log
+
+See [CHANGELOG.md](./CHANGELOG.md) for a list of changes in README.md
+
 ## Features
 
 - **Project-level dependency visualization**: See how your C# projects depend on each other

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
           "default": true,
           "description": "Include target framework version in the graph nodes"
         },
-        "csharp-dependency-graph.classDependencyColor": {
+        "csharpDependencyGraph.classDependencyColor": {
           "type": "string",
-          "default": "lightblue",
+          "default": "lightgray",
           "description": "Color for the class dependency graph. Colors can be specified in hex format (#RRGGBB) or by name (red, green, blue, lightblue, etc.)"
       },
         "csharpDependencyGraph.excludeTestProjects": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-csharp-dependency-graph",
   "displayName": "C# Dependency Graph Generator",
   "description": "Generate dependency graphs for C# projects - Helps visualize project dependencies or classes dependencies in a .NET solution.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "magic5644",
   "author": {
     "name": "Gildas Le Bournault"
@@ -16,7 +16,7 @@
     "Other"
   ],
   "galleryBanner": {
-    "color": "#C80000",
+    "color": "#000000",
     "theme": "dark"
   },
   "pricing": "Free",
@@ -46,6 +46,11 @@
           "default": true,
           "description": "Include target framework version in the graph nodes"
         },
+        "csharp-dependency-graph.classDependencyColor": {
+          "type": "string",
+          "default": "lightblue",
+          "description": "Color for the class dependency graph. Colors can be specified in hex format (#RRGGBB) or by name (red, green, blue, lightblue, etc.)"
+      },
         "csharpDependencyGraph.excludeTestProjects": {
           "type": "boolean",
           "default": true,
@@ -59,11 +64,6 @@
             "*TestProject*"
           ],
           "description": "Glob patterns to identify test projects to exclude"
-        },
-        "csharpDependencyGraph.includeClassDependencies": {
-          "type": "boolean",
-          "default": false,
-          "description": "Include class-level dependencies in the graph (more detailed but larger graph)"
         },
         "csharpDependencyGraph.excludeSourcePatterns": {
           "type": "array",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,6 @@ export function activate(context: vscode.ExtensionContext) {
         const includeNetVersion = config.get<boolean>('includeNetVersion', true);
         const excludeTestProjects = config.get<boolean>('excludeTestProjects', true);
         const testProjectPatterns = config.get<string[]>('testProjectPatterns', ["*Test*", "*Tests*", "*TestProject*"]);
-        const includeClassDependencies = config.get<boolean>('includeClassDependencies', false);
 
         // Ask the user for the type of graph to generate
         const graphType = await vscode.window.showQuickPick(
@@ -35,14 +34,19 @@ export function activate(context: vscode.ExtensionContext) {
           { placeHolder: 'Select the type of dependency graph to generate' }
         );
 
+        
         if (!graphType) {
           return; // User cancelled
         }
 
         const generateClassGraph = graphType.label === 'Class Dependencies';
+        let baseFilename = 'project-dependency-graph';
+        if (generateClassGraph) {
+          baseFilename = 'class-dependency-graph';
+        } 
 
         // Ask the user for a file path to save the graph
-        const defaultPath = path.join(workspaceFolder.uri.fsPath, 'dependency-graph.dot');
+        const defaultPath = path.join(workspaceFolder.uri.fsPath, `${baseFilename}.dot`);
         const saveUri = await vscode.window.showSaveDialog({
           defaultUri: vscode.Uri.file(defaultPath),
           filters: {
@@ -112,7 +116,8 @@ export function activate(context: vscode.ExtensionContext) {
                 progress.report({ message: `Generating .dot file with ${classDependencies.length} classes...` });
                 dotContent = generateDotFile(projects, {
                   includeNetVersion,
-                  includeClassDependencies: true
+                  includeClassDependencies: true,
+                  classDependencyColor: vscode.workspace.getConfiguration('csharp-dependency-graph').get('classDependencyColor') as string
                 }, classDependencies);
                 
                 // Log for debugging
@@ -123,7 +128,8 @@ export function activate(context: vscode.ExtensionContext) {
                 progress.report({ message: 'Class analysis failed, generating project-level graph instead...' });
                 dotContent = generateDotFile(projects, {
                   includeNetVersion, 
-                  includeClassDependencies: false
+                  includeClassDependencies: false,
+                  classDependencyColor: vscode.workspace.getConfiguration('csharp-dependency-graph').get('classDependencyColor') as string
                 });
               }
             } else {
@@ -131,7 +137,8 @@ export function activate(context: vscode.ExtensionContext) {
               progress.report({ message: 'Generating .dot file with project dependencies...' });
               dotContent = generateDotFile(projects, {
                 includeNetVersion,
-                includeClassDependencies: false
+                includeClassDependencies: false,
+                classDependencyColor: vscode.workspace.getConfiguration('csharp-dependency-graph').get('classDependencyColor') as string
               });
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,7 +117,7 @@ export function activate(context: vscode.ExtensionContext) {
                 dotContent = generateDotFile(projects, {
                   includeNetVersion,
                   includeClassDependencies: true,
-                  classDependencyColor: vscode.workspace.getConfiguration('csharp-dependency-graph').get('classDependencyColor') as string
+                  classDependencyColor: vscode.workspace.getConfiguration('csharpDependencyGraph').get('classDependencyColor') as string
                 }, classDependencies);
                 
                 // Log for debugging
@@ -129,7 +129,7 @@ export function activate(context: vscode.ExtensionContext) {
                 dotContent = generateDotFile(projects, {
                   includeNetVersion, 
                   includeClassDependencies: false,
-                  classDependencyColor: vscode.workspace.getConfiguration('csharp-dependency-graph').get('classDependencyColor') as string
+                  classDependencyColor: vscode.workspace.getConfiguration('csharpDependencyGraph').get('classDependencyColor') as string
                 });
               }
             } else {
@@ -138,7 +138,7 @@ export function activate(context: vscode.ExtensionContext) {
               dotContent = generateDotFile(projects, {
                 includeNetVersion,
                 includeClassDependencies: false,
-                classDependencyColor: vscode.workspace.getConfiguration('csharp-dependency-graph').get('classDependencyColor') as string
+                classDependencyColor: vscode.workspace.getConfiguration('csharpDependencyGraph').get('classDependencyColor') as string
               });
             }
 

--- a/src/graphGenerator.ts
+++ b/src/graphGenerator.ts
@@ -4,6 +4,7 @@ import { ClassDependency } from './csharpClassParser';
 interface GraphOptions {
   includeNetVersion: boolean;
   includeClassDependencies: boolean;
+  classDependencyColor: string;
 }
 
 /**
@@ -59,8 +60,8 @@ function generateClassDependencyGraph(
   for (const project of projects) {
     dotContent += `  subgraph "cluster_${project.name}" {\n`;
     dotContent += `    label="${project.name}${options.includeNetVersion && project.targetFramework ? ' (' + project.targetFramework + ')' : ''}";\n`;
-    dotContent += '    style="filled";\n';
-    dotContent += '    color=lightgrey;\n\n';
+    dotContent += `    style="filled";\n`;
+    dotContent += `    color=${options.classDependencyColor};\n\n`;
     
     // Add nodes for the classes of this project
     const projectClasses = classDependencies.filter(c => c.projectName === project.name);

--- a/src/graphGenerator.ts
+++ b/src/graphGenerator.ts
@@ -61,7 +61,7 @@ function generateClassDependencyGraph(
     dotContent += `  subgraph "cluster_${project.name}" {\n`;
     dotContent += `    label="${project.name}${options.includeNetVersion && project.targetFramework ? ' (' + project.targetFramework + ')' : ''}";\n`;
     dotContent += `    style="filled";\n`;
-    dotContent += `    color=${options.classDependencyColor};\n\n`;
+    dotContent += `    color="${options.classDependencyColor}";\n\n`;
     
     // Add nodes for the classes of this project
     const projectClasses = classDependencies.filter(c => c.projectName === project.name);


### PR DESCRIPTION
Introduce a CHANGELOG.md for version tracking and update the README to reference it. Fix the class dependency color configuration and set the default color to lightblue in the extension. Update the version to 0.2.0.