### PR TITLE
Update Node.js version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '24.x'
           cache: 'npm'
           
       - name: Get Version from Tag


### PR DESCRIPTION
Update the Node.js version to 24.x in the publish workflow to ensure compatibility and take advantage of the latest features.